### PR TITLE
Clamping Player Position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated Bevy to version 0.8
 - Updated Bevy ECS LDtk to version 0.4
 - Updated Bevy Kira Audio to version 0.12
+- Restricted Player Movement to Level Boundries
 
 ## [0.2.0] - 2022-07-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Updated Bevy to version 0.8
 - Updated Bevy ECS LDtk to version 0.4
 - Updated Bevy Kira Audio to version 0.12
-- Restricted Player Movement to Level Boundries
+- Restricted Player Movement to Level Boundaries
 
 ## [0.2.0] - 2022-07-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - This project uses [ISO Standard](https://www.iso.org/iso-8601-date-and-time-format.html) date formatting
 
 ## [Unreleased]
+### Added
+- Unit Testing for Level Boundaries.
+
 ### Changed
 - Updated Bevy to version 0.8
 - Updated Bevy ECS LDtk to version 0.4

--- a/assets/maps/hh_test.ldtk
+++ b/assets/maps/hh_test.ldtk
@@ -2097,16 +2097,16 @@
 					"entityInstances": [
 						{
 							"__identifier": "Player",
-							"__grid": [6,20],
+							"__grid": [0,0],
 							"__pivot": [0.5,1],
 							"__tags": [],
 							"__tile": { "tilesetUid": 8, "x": 0, "y": 128, "w": 64, "h": 64 },
 							"__smartColor": "#94D9B3",
-							"iid": "a2085d50-b4d0-11ec-9d5f-63225cc12cea",
+							"iid": "bd0146d0-2a00-11ed-98da-dfbf0f7db078",
 							"width": 64,
 							"height": 64,
 							"defUid": 4,
-							"px": [408,1312],
+							"px": [32,64],
 							"fieldInstances": []
 						}
 					]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,12 @@ use bevy_kira_audio::{AudioApp, AudioPlugin};
 use entities::player::{PlayerBumpChannel, PlayerBundle, PlayerMovementActions, PlayerWalkChannel};
 use mechanics::{camera::move_camera, input::*};
 
+#[derive(Default)]
+pub struct LevelDimensions {
+    pub width: usize,
+    pub height: usize,
+}
+
 /// Loads the LDtk test map with a Camera into the game at the origin (0,0,0).
 fn spawn_map(mut commands: Commands, asset_spawner: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
@@ -35,13 +41,16 @@ fn main() {
         .add_startup_system(load_player_movement_sound)
         .add_startup_system(load_player_bump_sound)
         .insert_resource(LevelSelection::Identifier("Test_level".to_string()))
+        .init_resource::<LevelDimensions>()
         .add_audio_channel::<MusicChannel>()
         .add_audio_channel::<PlayerWalkChannel>()
         .add_audio_channel::<PlayerBumpChannel>()
         .add_event::<Movement>()
         .add_event::<PlayerMovementActions>()
+        .add_system(update_level_dimensions)
         .add_system(player_input)
         .add_system(move_player)
+        .add_system(bound_player_movement)
         .add_system(move_camera)
         .add_system(play_level_music)
         .add_system(play_player_movement_sound)

--- a/src/mechanics/input.rs
+++ b/src/mechanics/input.rs
@@ -1,4 +1,7 @@
-use crate::entities::player::{Player, PlayerMovementActions};
+use crate::{
+    entities::player::{Player, PlayerMovementActions},
+    LevelDimensions,
+};
 use bevy::{prelude::*, sprite::collide_aabb::collide};
 use bevy_ecs_ldtk::{EntityInstance, LdtkLevel};
 
@@ -21,12 +24,59 @@ pub fn player_input(input: Res<Input<KeyCode>>, mut input_broadcast: EventWriter
     }
 }
 
+pub fn update_level_dimensions(
+    level_query: Query<&Handle<LdtkLevel>>,
+    loaded_levels: Res<Assets<LdtkLevel>>,
+    mut level_dimension: ResMut<LevelDimensions>,
+) {
+    if !(loaded_levels.is_added() || loaded_levels.is_changed()) {
+        return;
+    }
+
+    if loaded_levels.is_empty() || level_query.is_empty() {
+        return;
+    }
+
+    let level_info = &loaded_levels
+        .get(level_query.single())
+        .expect("The level should exist by now.")
+        .level;
+    let level_height = level_info.px_hei as usize;
+    let level_width = level_info.px_wid as usize;
+
+    level_dimension.width = level_width;
+    level_dimension.height = level_height;
+}
+
+pub fn bound_player_movement(
+    level_dimension: Res<LevelDimensions>,
+    mut player_query: Query<&mut Transform, (Changed<Transform>, With<Player>)>,
+) {
+    if player_query.is_empty() {
+        return;
+    }
+
+    let mut player_transform = player_query.get_single_mut().unwrap();
+
+    let tile_side_length = 64.0;
+    let tile_mid_point = tile_side_length / 2.0;
+
+    player_transform.translation.x = player_transform.translation.x.clamp(
+        tile_mid_point,
+        level_dimension.width as f32 - tile_mid_point,
+    );
+
+    player_transform.translation.y = player_transform.translation.y.clamp(
+        tile_mid_point,
+        level_dimension.height as f32 - tile_mid_point,
+    );
+}
+
 pub fn move_player(
     mut input_receiver: EventReader<Movement>,
     mut player_query: Query<(&mut Transform, &mut TextureAtlasSprite), With<Player>>,
     tile_query: Query<&EntityInstance>,
-    level_query: Query<&Handle<LdtkLevel>>,
-    loaded_levels: Res<Assets<LdtkLevel>>,
+    level_dimension: Res<LevelDimensions>,
     mut player_movement_broadcast: EventWriter<PlayerMovementActions>,
 ) {
     for movement_action in input_receiver.iter() {
@@ -53,24 +103,9 @@ pub fn move_player(
             }
         }
 
-        let level_info = &loaded_levels
-            .get(level_query.single())
-            .expect("The level should exist by now.")
-            .level;
-        let level_height = level_info.px_hei;
-        let level_width = level_info.px_wid;
-
         let tile_side_length = 64.0;
-        let tile_mid_point = tile_side_length / 2.0;
 
-        let mut projected_position = player_transform.translation + direction;
-        projected_position.x = projected_position
-            .x
-            .clamp(tile_mid_point, level_width as f32 - tile_mid_point);
-            
-        projected_position.y = projected_position
-            .y
-            .clamp(tile_mid_point, level_height as f32 - tile_mid_point);
+        let projected_position = player_transform.translation + direction;
 
         let collision_tiles = tile_query
             .iter()
@@ -85,7 +120,7 @@ pub fn move_player(
         for &collision_tile in collision_tiles.iter() {
             let tile_position = Vec3::new(
                 collision_tile.px.x as f32,
-                (level_height - (collision_tile.px.y)) as f32,
+                (level_dimension.height as i32 - (collision_tile.px.y)) as f32,
                 0.0,
             );
 
@@ -103,5 +138,240 @@ pub fn move_player(
         }
         player_transform.translation = projected_position;
         player_movement_broadcast.send(PlayerMovementActions::Walking);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_LEVEL_WIDTH: usize = 1344;
+    const TEST_LEVEL_HEIGHT: usize = 1472;
+
+    const TEST_LEVEL_WIDTH_IN_BOUNDS: f32 = 500.0;
+    const TEST_LEVEL_WIDTH_OUT_LBOUNDS: f32 = -500.0;
+    const TEST_LEVEL_WIDTH_OUT_RBOUNDS: f32 = 1500.0;
+
+    const TEST_LEVEL_HEIGHT_IN_BOUNDS: f32 = 500.0;
+    const TEST_LEVEL_HEIGHT_OUT_TBOUNDS: f32 = 1600.0;
+    const TEST_LEVEL_HEIGHT_OUT_BBOUNDS: f32 = -500.0;
+
+    const PLAYER_MIDPOINT: usize = 32;
+
+    fn setup_app_bounds_checking() -> App {
+        let mut app = App::new();
+
+        app.insert_resource(LevelDimensions {
+            width: TEST_LEVEL_WIDTH,
+            height: TEST_LEVEL_HEIGHT,
+        });
+
+        app.add_system(bound_player_movement);
+
+        app
+    }
+
+    #[test]
+    fn within_bounds() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform = Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0);
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_left() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_OUT_LBOUNDS, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform = Transform::from_xyz(PLAYER_MIDPOINT as f32, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0);
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_topleft() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_OUT_LBOUNDS, TEST_LEVEL_HEIGHT_OUT_TBOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform = Transform::from_xyz(
+            PLAYER_MIDPOINT as f32,
+            (TEST_LEVEL_HEIGHT - PLAYER_MIDPOINT) as f32,
+            0.0,
+        );
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_bottomleft() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_OUT_LBOUNDS, TEST_LEVEL_HEIGHT_OUT_BBOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform =
+            Transform::from_xyz(PLAYER_MIDPOINT as f32, PLAYER_MIDPOINT as f32, 0.0);
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_right() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_OUT_RBOUNDS, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform =
+            Transform::from_xyz((TEST_LEVEL_WIDTH - PLAYER_MIDPOINT) as f32, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0);
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_topright() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_OUT_RBOUNDS, TEST_LEVEL_HEIGHT_OUT_TBOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform = Transform::from_xyz(
+            (TEST_LEVEL_WIDTH - PLAYER_MIDPOINT) as f32,
+            (TEST_LEVEL_HEIGHT - PLAYER_MIDPOINT) as f32,
+            0.0,
+        );
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_bottomright() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_OUT_RBOUNDS, TEST_LEVEL_HEIGHT_OUT_BBOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform = Transform::from_xyz(
+            (TEST_LEVEL_WIDTH - PLAYER_MIDPOINT) as f32,
+            PLAYER_MIDPOINT as f32,
+            0.0,
+        );
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_top() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, TEST_LEVEL_HEIGHT_OUT_TBOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform =
+            Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, (TEST_LEVEL_HEIGHT - PLAYER_MIDPOINT) as f32, 0.0);
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
+    }
+
+    #[test]
+    fn out_of_bounds_bottom() {
+        let mut app = setup_app_bounds_checking();
+
+        let player_id = app
+            .world
+            .spawn()
+            .insert_bundle((Player, Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, TEST_LEVEL_HEIGHT_OUT_BBOUNDS, 0.0)))
+            .id();
+
+        app.update();
+
+        let player_query = app.world.get::<Transform>(player_id);
+        assert!(player_query.is_some());
+
+        let expected_transform = Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, PLAYER_MIDPOINT as f32, 0.0);
+        let actual_transform = *player_query.unwrap();
+
+        assert_eq!(expected_transform, actual_transform);
     }
 }


### PR DESCRIPTION
- Used clamp to restrict projected player position within level bounds


Closes #19 