### PR TITLE
Converted Game to Use States

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Added
 - Tutorial Level Map, including free-to-use placeholder assets
 - Unit Testing for Level Boundaries
-- Spellchecking logging for mistyped asset loading.
+- Spellchecking logging for mistyped asset loading
 
 ### Changed
 - Updated Bevy to version 0.9
@@ -17,6 +17,7 @@
 - Restricted Player Movement to Level Boundaries
 - Restricted Camera Movement to Level Boundaries
 - Game App Setup moved into Plugins
+- Plugin system now load via Game States
 
 ### Fixed
 - Camera now maintains own z position instead of adopting the players
@@ -25,12 +26,12 @@
 
 ## [0.2.0] - 2022-07-28
 ### Added
-- Making Universal Builds for MacOS.
+- Making Universal Builds for MacOS
 - Play Background Music
 - Play Movement Based SFX (Footsteps & Collision)
 
 ### Fixed
-- Making Windows/MacOS/Linux executables automatically per new version.
+- Making Windows/MacOS/Linux executables automatically per new version
 
 ## [0.1.0] - 2022-06-12
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,12 @@ use bevy_ecs_ldtk::prelude::*;
 use bevy_kira_audio::AudioPlugin;
 use plugins::smart_asset_io::SmartAssetIoPlugin;
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum AppState {
+    MainMenu,
+    InGame
+}
+
 fn main() {
     App::new()
         .add_plugins(
@@ -23,7 +29,8 @@ fn main() {
                 // An explanation for this line can be found in the referencing bevy example:
                 // https://github.com/bevyengine/bevy/blob/main/examples/asset/custom_asset_io.rs#L69
                 .add_before::<bevy::asset::AssetPlugin, _>(SmartAssetIoPlugin),
-        )
+        )        
+        .add_state(AppState::InGame)
         .add_plugin(LdtkPlugin)
         .add_plugin(AudioPlugin)
         .add_plugin(plugins::levels::LevelsPlugin)

--- a/src/plugins/levels.rs
+++ b/src/plugins/levels.rs
@@ -5,21 +5,29 @@ use bevy_kira_audio::AudioApp;
 use crate::{
     audio::music::{play_level_music, MusicChannel},
     mechanics::{camera::*, input::*},
-    visuals::map::*,
+    visuals::map::*, 
+    AppState,
 };
 
 pub struct LevelsPlugin;
 
 impl Plugin for LevelsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(spawn_map)
+        app
+            .add_system_set(
+                SystemSet::on_enter(AppState::InGame)
+                .with_system(spawn_map)
+            )
             .insert_resource(LevelSelection::Identifier("Level_0".to_string()))
             .init_resource::<LevelDimensions>()
-            .add_system(move_camera)
-            .add_system(player_input)
-            .add_system(play_level_music)
-            .add_system(update_level_dimensions)
-            .add_system(update_camera_on_resolution_change)
+            .add_system_set(
+                SystemSet::on_update(AppState::InGame)
+                .with_system(move_camera)
+                .with_system(player_input)
+                .with_system(play_level_music)
+                .with_system(update_level_dimensions)
+                .with_system(update_camera_on_resolution_change)
+            )
             .add_audio_channel::<MusicChannel>()
             .add_event::<Movement>();
     }

--- a/src/plugins/playable_character.rs
+++ b/src/plugins/playable_character.rs
@@ -2,18 +2,26 @@ use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 use bevy_kira_audio::AudioApp;
 
-use crate::{audio::sfx::*, entities::player::*, mechanics::input::*};
+use crate::{audio::sfx::*, entities::player::*, mechanics::input::*, AppState};
 
 pub struct PlayableCharacterPlugin;
 
 impl Plugin for PlayableCharacterPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(load_player_movement_sound)
-            .add_startup_system(load_player_bump_sound)
-            .add_system(move_player)
-            .add_system(bound_player_movement)
-            .add_system(play_player_movement_sound)
-            .add_system(play_player_bump_sound)
+        app
+            .add_system_set(
+                SystemSet::on_enter(AppState::InGame)
+                .with_system(load_player_movement_sound)
+                .with_system(load_player_bump_sound)
+            )
+            .add_system_set(
+                SystemSet::on_update(AppState::InGame)
+                .with_system(move_player)
+                .with_system(bound_player_movement)
+                .with_system(play_player_movement_sound)
+                .with_system(play_player_bump_sound)
+
+            )
             .add_audio_channel::<PlayerWalkChannel>()
             .add_audio_channel::<PlayerBumpChannel>()
             .add_event::<PlayerMovementActions>()


### PR DESCRIPTION
## What is the purpose of these changes?
Currently, all the game systems run when the application is launched, placing the player in the overworld. To facilitate menus and other configurations we introduce the concept of states. Via states the game will be able to transition from different modes efficiently and will maintain a level of organization that will aid future development.

## What has changed?
Tied system loading in various plugins to a state.

## How can I verify this works?
1. On the "states" branch run the program.
2. Observe that the game loads to the InGame state as intended.
3. In main.rs change line 33 `.add_state(AppState::InGame)` to `.add_state(AppState::MainMenu)`.
5. Run the program again.
6. Observe that the screen is blank, indicating that MainMenu is the active state and none of the InGame systems were loaded.