### PR TITLE
Add Caching to CI Scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Install Audio Driver via Alsa for Linux
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,25 +23,19 @@ jobs:
              fi
         shell: bash
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
+          
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Run cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy
 

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -8,12 +8,8 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            components: rustfmt
-            override: true
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - uses: mbrobbel/rustfmt-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: Zip release
         uses: vimtor/action-zip@v1
         with:
-          files: target/release/assets/ target/release/credits/ target/release/${{ env.GAME_EXECUTABLE_NAME }}.exe
+          files: target/release/assets/ target/release/${{ env.GAME_EXECUTABLE_NAME }}.exe
           dest: ${{ env.GAME_EXECUTABLE_NAME }}_windows.zip
       - name: Create Installer
         if: ${{ env.BUILD_INSTALLER }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,39 +4,59 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version - in the form of v1.2.3'
+        required: true
+        type: string
 
+# ToDo: adapt names
 env:
+  # heads-up: this value is used as a pattern in an sed command as a workaround for a trunk issue
+  #   if you use special characters, take a look at the 'Make paths relative' step in the 'build-web' job
   GAME_EXECUTABLE_NAME: helping-hand
   GAME_OSX_APP_NAME: HelpingHand
 
-jobs:
-  build-macOS:
-    runs-on: macOS-latest
+permissions:
+  contents: write
 
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
     steps:
       - name: Get tag
         id: tag
-        uses: dawidd6/action-get-tag@v1
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: ${{ inputs.version || steps.tag.outputs.tag }}
+
+  build-macOS:
+    runs-on: macos-latest
+    needs: get-version
+    env:
+      # macOS 11.0 Big Sur is the first version to support universal binaries
+      MACOSX_DEPLOYMENT_TARGET: 11.0
+      VERSION: ${{needs.get-version.outputs.version}}
+    steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install rust toolchain for Apple Silicon
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: aarch64-apple-darwin
-          override: true
+          targets: aarch64-apple-darwin
       - name: Build release for Apple Silicon
         run: |
-          SDKROOT=$(xcrun -sdk macosx --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version) cargo build --release --target=aarch64-apple-darwin
+          SDKROOT=$(xcrun -sdk macosx --show-sdk-path) cargo build --release --target=aarch64-apple-darwin
       - name: Install rust toolchain for Apple x86
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: x86_64-apple-darwin
-          override: true
+          targets: x86_64-apple-darwin
       - name: Build release for x86 Apple
         run: |
-          SDKROOT=$(xcrun -sdk macosx --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version) cargo build --release --target=x86_64-apple-darwin
+          SDKROOT=$(xcrun -sdk macosx --show-sdk-path) cargo build --release --target=x86_64-apple-darwin
       - name: Create Universal Binary
         run: |
           lipo -create -output target/release/${{ env.GAME_EXECUTABLE_NAME }} target/aarch64-apple-darwin/release/${{ env.GAME_EXECUTABLE_NAME }} target/x86_64-apple-darwin/release/${{ env.GAME_EXECUTABLE_NAME }}
@@ -54,24 +74,22 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.GAME_EXECUTABLE_NAME }}.dmg
-          asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ steps.tag.outputs.tag }}_macOS.dmg
-          tag: ${{ github.ref }}
+          asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ env.VERSION }}_macOS.dmg
+          release_name: ${{ env.VERSION }}
           overwrite: true
 
   build-linux:
     runs-on: ubuntu-latest
-
+    needs: get-version
+    env:
+      VERSION: ${{needs.get-version.outputs.version}}
     steps:
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Build release
@@ -90,24 +108,28 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.GAME_EXECUTABLE_NAME }}_linux.tar.gz
-          asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ steps.tag.outputs.tag }}_linux.tar.gz
-          tag: ${{ github.ref }}
+          asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ env.VERSION }}_linux.tar.gz
+          release_name: ${{ env.VERSION }}
           overwrite: true
 
   build-windows:
     runs-on: windows-latest
-
+    needs: get-version
+    env:
+      VERSION: ${{needs.get-version.outputs.version}}
+      BUILD_INSTALLER: false
     steps:
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
+      - name: Install dotnet
+        if: ${{ env.BUILD_INSTALLER }}
+        uses: actions/setup-dotnet@v3
+        with:
+          global-json-file: build/windows/installer/global.json
       - name: Build release
         run: |
           cargo build --release
@@ -117,14 +139,25 @@ jobs:
       - name: Zip release
         uses: vimtor/action-zip@v1
         with:
-          files: target/release/assets/ target/release/${{ env.GAME_EXECUTABLE_NAME }}.exe
+          files: target/release/assets/ target/release/credits/ target/release/${{ env.GAME_EXECUTABLE_NAME }}.exe
           dest: ${{ env.GAME_EXECUTABLE_NAME }}_windows.zip
+      - name: Create Installer
+        if: ${{ env.BUILD_INSTALLER }}
+        run: dotnet build -p:Version=1.2.3 -c Release build/windows/installer/Installer.wixproj --output installer
       - name: Upload release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.GAME_EXECUTABLE_NAME }}_windows.zip
-          asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ steps.tag.outputs.tag }}_windows.zip
+          asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ env.VERSION }}_windows.zip
           tag: ${{ github.ref }}
           overwrite: true
-
+      - name: Upload installer
+        if: ${{ env.BUILD_INSTALLER }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+         repo_token: ${{ secrets.GITHUB_TOKEN }}
+         file: installer/en-US/installer.msi
+         asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ steps.tag.outputs.tag }}_windows.msi
+         release_name: ${{ env.VERSION }}
+         overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Unit Testing for Level Boundaries
 - Spellchecking logging for mistyped asset loading
 - Main Menu w/ Quit and Play Buttons that exit the application and transition to the game respectively
+- Caching for Builds on GitHub.
 
 ### Changed
 - Updated Bevy to version 0.10
@@ -19,6 +20,7 @@
 - Restricted Camera Movement to Level Boundaries
 - Game App Setup moved into Plugins
 - Plugin system now load via Game States
+- Updated dependencies for Continuous Integration GitHub Actions.
 
 ### Fixed
 - Camera now maintains own z position instead of adopting the players


### PR DESCRIPTION
## What is the purpose of these changes?
This pull request addresses two concerns:
1. Build times take 5 minutes or more with the state of the project as-is. Build caching would reduce this greatly.
2. A lot of the rust-based GitHub Action dependencies are deprecated, so some updates were needed.

## What has changed?
- Added build caching to CI script.
- Changed from Action-RS to dtolnay rust toolchain dependency for invoking Rust commands.
- Updated Release script with the latest from our reference at bevy_game_template.

## How can I verify this works?
1. Let the GitHub Actions finish by the time I publish this PR.
2. In the commit history, click the checkmark of the oldest commit. Pick any OS.
3. Click Summary at the top.
4. Note the total duration.
5. Repeat steps 2-4 with the newest commit, noticing the difference in total duration.

