### PR TITLE
Unwraps to Expects

### DIFF
--- a/src/diagnostics/missing_file_finder.rs
+++ b/src/diagnostics/missing_file_finder.rs
@@ -87,7 +87,7 @@ fn edit_distance(word1: &str, word2: &str) -> usize {
 /// the original_path.
 fn to_canonical_asset_path(original_path: &Path) -> PathBuf {
     let root_directory = env!("CARGO_MANIFEST_DIR").to_string();
-    let asset_directory = root_directory + "/assets/" + original_path.to_str().unwrap();
+    let asset_directory = root_directory + "/assets/" + original_path.to_str().expect("to_cononical_asset_path: original path could not be found");
 
     Path::new(&asset_directory).to_path_buf()
 }
@@ -113,8 +113,8 @@ fn get_closest_file_path(original_path: &Path) -> PathBuf {
 
     for asset_file_path in &asset_file_paths {
         file_difference_scores.push(edit_distance(
-            original_path.to_str().unwrap(),
-            asset_file_path.to_str().unwrap(),
+            original_path.to_str().expect("get_closest_file_path: original path could not be found"),
+            asset_file_path.to_str().expect("get_closest_file_path: asset file path could not be found"),
         ));
     }
 

--- a/src/mechanics/camera.rs
+++ b/src/mechanics/camera.rs
@@ -22,8 +22,8 @@ pub fn move_camera(
         return;
     }
 
-    let (mut camera_transform, camera_bounds) = camera_query.get_single_mut().unwrap();
-    let player_transform = player_query.get_single().unwrap();
+    let (mut camera_transform, camera_bounds) = camera_query.get_single_mut().expect("move_camera: could not find camera");
+    let player_transform = player_query.get_single().expect("move_camera: could not find player");
 
     let camera_width = camera_bounds.area.width() + 1.0;
     let camera_height = camera_bounds.area.height() + 1.0;
@@ -66,7 +66,7 @@ pub fn update_camera_on_resolution_change(
         return;
     }
 
-    let mut player_position = player_query.get_single_mut().unwrap();
+    let mut player_position = player_query.get_single_mut().expect("update_camera_on_resolution_change: player could not be found");
 
     //Camera updates its position based on changes to player position, thus we add 0 to force a change to player position
     player_position.translation.x += 0.0;
@@ -146,7 +146,7 @@ mod tests {
         let expected_transform_x = TEST_LEVEL_WIDTH_IN_BOUNDS;
         let expected_transform_y = TEST_LEVEL_HEIGHT_IN_BOUNDS;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("within_bounds [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 
@@ -179,7 +179,7 @@ mod tests {
         let expected_transform_x = CAMERA_MIDPOINT as f32;
         let expected_transform_y = TEST_LEVEL_HEIGHT_IN_BOUNDS;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_left [test]: camera could not be found");
 
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
@@ -213,7 +213,7 @@ mod tests {
         let expected_transform_x = CAMERA_MIDPOINT as f32;
         let expected_transform_y = (TEST_LEVEL_HEIGHT - CAMERA_MIDPOINT) as f32;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_topleft [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 
@@ -246,7 +246,7 @@ mod tests {
         let expected_transform_x = CAMERA_MIDPOINT as f32;
         let expected_transform_y = CAMERA_MIDPOINT as f32;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_bottomleft [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 
@@ -279,7 +279,7 @@ mod tests {
         let expected_transform_x = (TEST_LEVEL_WIDTH - CAMERA_MIDPOINT) as f32;
         let expected_transform_y = TEST_LEVEL_HEIGHT_IN_BOUNDS;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_right [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 
@@ -312,7 +312,7 @@ mod tests {
         let expected_transform_x = (TEST_LEVEL_WIDTH - CAMERA_MIDPOINT) as f32;
         let expected_transform_y = (TEST_LEVEL_HEIGHT - CAMERA_MIDPOINT) as f32;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_topright [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 
@@ -345,7 +345,7 @@ mod tests {
         let expected_transform_x = (TEST_LEVEL_WIDTH - CAMERA_MIDPOINT) as f32;
         let expected_transform_y = CAMERA_MIDPOINT as f32;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_bottomright [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 
@@ -378,7 +378,7 @@ mod tests {
         let expected_transform_x = TEST_LEVEL_HEIGHT_IN_BOUNDS;
         let expected_transform_y = (TEST_LEVEL_HEIGHT - CAMERA_MIDPOINT) as f32;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_top [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 
@@ -411,7 +411,7 @@ mod tests {
         let expected_transform_x = TEST_LEVEL_WIDTH_IN_BOUNDS;
         let expected_transform_y = CAMERA_MIDPOINT as f32;
 
-        let actual_transform = *camera_query.unwrap();
+        let actual_transform = *camera_query.expect("out_of_bounds_bottom [test]: camera could not be found");
         let actual_transform_x = actual_transform.translation.x;
         let actual_transform_y = actual_transform.translation.y;
 

--- a/src/mechanics/input.rs
+++ b/src/mechanics/input.rs
@@ -72,7 +72,7 @@ pub fn bound_player_movement(
         return;
     }
 
-    let mut player_transform = player_query.get_single_mut().unwrap();
+    let mut player_transform = player_query.get_single_mut().expect("bound_player_movement: The player does not exist, but they should");
 
     let tile_side_length = 64.0;
     let tile_mid_point = tile_side_length / 2.0;
@@ -255,7 +255,7 @@ pub fn interact_entity(
                 .expect("interact_entity: Could not find Interactive text in Interactive Tile");
 
             if let String(message) = &text.value {
-                println!("{}", message.as_ref().unwrap());
+                println!("{}", message.as_ref().expect("interact_entity: Could not display message"));
             }
         }
     }
@@ -311,7 +311,7 @@ mod tests {
 
         let expected_transform =
             Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0);
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("within_bound [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -340,7 +340,7 @@ mod tests {
 
         let expected_transform =
             Transform::from_xyz(PLAYER_MIDPOINT as f32, TEST_LEVEL_HEIGHT_IN_BOUNDS, 0.0);
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_left [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -372,7 +372,7 @@ mod tests {
             (TEST_LEVEL_HEIGHT - PLAYER_MIDPOINT) as f32,
             0.0,
         );
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_topleft [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -401,7 +401,7 @@ mod tests {
 
         let expected_transform =
             Transform::from_xyz(PLAYER_MIDPOINT as f32, PLAYER_MIDPOINT as f32, 0.0);
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_bottomleft [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -433,7 +433,7 @@ mod tests {
             TEST_LEVEL_HEIGHT_IN_BOUNDS,
             0.0,
         );
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_right [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -465,7 +465,7 @@ mod tests {
             (TEST_LEVEL_HEIGHT - PLAYER_MIDPOINT) as f32,
             0.0,
         );
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_topright [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -497,7 +497,7 @@ mod tests {
             PLAYER_MIDPOINT as f32,
             0.0,
         );
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_bottomright [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -529,7 +529,7 @@ mod tests {
             (TEST_LEVEL_HEIGHT - PLAYER_MIDPOINT) as f32,
             0.0,
         );
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_top [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }
@@ -558,7 +558,7 @@ mod tests {
 
         let expected_transform =
             Transform::from_xyz(TEST_LEVEL_WIDTH_IN_BOUNDS, PLAYER_MIDPOINT as f32, 0.0);
-        let actual_transform = *player_query.unwrap();
+        let actual_transform = *player_query.expect("out_of_bounds_bottom [test]: Player could not be found");
 
         assert_eq!(expected_transform, actual_transform);
     }


### PR DESCRIPTION
Changed all unwraps to expects with descriptive messages

## What is the purpose of these changes?
Expects with proper messages describing the error helps with tracking down issues in the future.

## What has changed?
All upwraps that could be found have been changed to expects and given appropriate error messages.

## How can I verify this works?
1. Open the code in the editor of your choice
2. Search various files for the term "unwrap" and see that there are not results
3. Search various files for the term "expect" and observe the error messages that now exist
