### PR TITLE
Movement Stuttering Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - macOS Sonoma crashing the application by updating dependencies.
 - Missing File Finder thinking assets folder doesn't exist for release builds.
+- Movement no long stutters.
 
 ## [0.3.0] - 2023-09-22
 ### Added

--- a/src/plugins/playable_character.rs
+++ b/src/plugins/playable_character.rs
@@ -18,11 +18,11 @@ impl Plugin for PlayableCharacterPlugin {
                 move_entity,
                 animate_entity,
                 interact_entity,
-                display_interactive_message,
-                transition_level,
+                display_interactive_message.after(interact_entity),
+                transition_level.after(interact_entity),
                 bound_player_movement,
-                play_player_movement_sound,
-                play_player_bump_sound,
+                play_player_movement_sound.after(move_entity),
+                play_player_bump_sound.after(move_entity),
             )
                 .run_if(in_state(AppState::InGame)),
         )


### PR DESCRIPTION
## What is the purpose of these changes?
Players moving the character would occasionally witness the whole game stuttering, where the audio would be choppy, and the screen would react by jittering. However, this would not happen all the time, suggesting some sort of racing taking place, thus we were not able to identify whether this has been a longer lasting issue.

This PR hopes to effectively close #45 once and for all by the introduction of [Explicit System Ordering](https://bevy-cheatbook.github.io/programming/system-order.html#does-it-even-matter) to ensure that racing is not possible.

## What has changed?
- Movement no long stutters.

## How can I verify this works?
1. Start the game.
2. Click Play to enter the overworld.
3. Move the player to the right just enough to trigger the camera to move as well.
4. Observe the jittering of the screen and the stuttering of the audio is not happening anymore.
5. Repeat 1-4 at least 10 times to verify that this does not race anymore.

